### PR TITLE
chore(scripts): Switch from mamba run to environment activation

### DIFF
--- a/run_ml.sh
+++ b/run_ml.sh
@@ -265,8 +265,6 @@ do_run() {
     info "Starting ML-Evolve Agent"
     echo "📋 Task Name: $task_name"
     echo "🔧 Environment: $ENV_NAME (activated)"
-    echo "🔧 CONDA_PREFIX: ${CONDA_PREFIX:-not set}"
-    echo "🔧 LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:-not set}"
     echo "📁 Task Directory: $task_dir"
     echo "📁 Task Data: $task_data_path"
     echo "📝 Config: $task_config"

--- a/run_mlebench.sh
+++ b/run_mlebench.sh
@@ -312,8 +312,6 @@ do_run() {
     echo "=================================================================="
     info "Starting ML-Evolve Agent for: $competition_id"
     echo "🔧 Environment: $ENV_NAME (activated)"
-    echo "🔧 CONDA_PREFIX: ${CONDA_PREFIX:-not set}"
-    echo "🔧 LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:-not set}"
     echo "📁 Task Data: $task_data_path"
     echo "📝 Config: $agent_config_path"
     echo "🔧 Evaluator: $eval_program"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

`mamba run` may cause issues with environment variables or path resolution in some cases, leading to unexpected behavior when executing scripts.

### What is changed and the side effects?

Changed:
- `run_ml.sh`: Replaced `mamba run -n <env>` with `conda activate <env>` followed by direct command execution
- `run_mlebench.sh`: Same change as above

Side effects:
- Performance effects: None
- Breaking backward compatibility: None. Users with conda/mamba environments can run scripts as before.


---
### Check List:
- [x] Please make sure your changes are compilable.
- [ ] When providing us with a new feature, it is best to add related tests.
- [x] Please follow [Contributor Covenant Code of Conduct](https://github.com/baidu-baige/LoongFlow/blob/main/CONTRIBUTING.md).

