### PR TITLE
fix: change finalizer role to assistant for multi-turn conversation

### DIFF
--- a/src/loongflow/framework/react/components/default_finalizer.py
+++ b/src/loongflow/framework/react/components/default_finalizer.py
@@ -118,13 +118,13 @@ class DefaultFinalizer(Finalizer):
             return Message.from_text(
                 sender="finalizer",
                 data=output_data.get("response", ""),
-                role=Role.TOOL,
+                role=Role.ASSISTANT,
                 mime_type=MimeType.TEXT_PLAIN,
             )
         return Message.from_text(
             sender="finalizer",
             data=output_data,
-            role=Role.TOOL,
+            role=Role.ASSISTANT,
             mime_type=MimeType.APPLICATION_JSON,
         )
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:
Finalizer role 'tool' does not support multi-turn conversations. Changed to 'assistant' to enable continuous dialogue.

### What is changed and the side effects?

Changed:
- Modified finalizer return role: 'tool' → 'assistant'
- Enabled multi-turn conversation support

Side effects:
- Performance effects:
  - Better performance in multi-turn scenarios.

- Breaking backward compatibility: 
  - None

---
### Check List:
- [x] Please make sure your changes are compilable.
- [x] When providing us with a new feature, it is best to add related tests.
- [x] Please follow [Contributor Covenant Code of Conduct](https://github.com/baidu-baige/LoongFlow/blob/main/CONTRIBUTING.md).
