### PR TITLE
fix: ML Agent now uses user-provided initial_code for first iteration

### DIFF
--- a/agents/ml_agent/planner/ml_planner.py
+++ b/agents/ml_agent/planner/ml_planner.py
@@ -140,7 +140,22 @@ class MLPlannerAgent(Worker):
             f"Trace ID: {context.trace_id}: MLPlanner: Get sample parent solution: {parent}"
         )
 
-        parent_dict = parent if parent else {}
+        # Prepare initial solution as fallback when memory is empty
+        init_solution = context.init_solution
+        init_evaluation = context.init_evaluation or ""
+        init_score = 0.0
+        if context.init_score is not None:
+            init_score = context.init_score
+
+        init_parent = {
+            "solution": init_solution,
+            "score": init_score,
+            "evaluation": init_evaluation,
+            "summary": "This is the initial solution provided by user, start evolution from here",
+        }
+
+        # Use init_parent as fallback when no solution exists in memory
+        parent_dict = parent if parent else (init_parent if init_solution else {})
         parent_json = json.dumps(parent_dict, ensure_ascii=False, indent=2)
         Workspace.write_planner_parent_info(context, parent_json)
         parent_info_file_path = Workspace.get_planner_parent_info_path(context)


### PR DESCRIPTION
## Summary

- Fixed ML Agent to use user-provided `initial_code` as parent when memory is empty
- ML Agent now follows the same pattern as Math Agent for initial solution handling
- This helps ML Agent find the first feasible solution more easily

## Problem

When memory is empty (first iteration), ML Agent was using an empty dict `{}` as parent, ignoring the user-provided `initial_code` configuration. This made it difficult for ML Agent to explore the first feasible solution.

## Solution

Modified `ml_planner.py` to use `init_parent` as fallback when no solution exists in memory, following the same pattern as Math Agent (`plan_agent.py`).

### Before
```python
parent = self.database.sample_solution(context.island_id)
parent_dict = parent if parent else {}  # ❌ Empty dict, initial_code lost
```

### After
```python
parent = self.database.sample_solution(context.island_id)

# Prepare initial solution as fallback when memory is empty
init_solution = context.init_solution
init_evaluation = context.init_evaluation or ""
init_score = 0.0
if context.init_score is not None:
    init_score = context.init_score

init_parent = {
    "solution": init_solution,
    "score": init_score,
    "evaluation": init_evaluation,
    "summary": "This is the initial solution provided by user, start evolution from here",
}

# Use init_parent as fallback when no solution exists in memory
parent_dict = parent if parent else (init_parent if init_solution else {})
```

## Usage

Users can now provide initial code in `task_config.yaml`:

```yaml
evolve:
  initial_code: |
    import pandas as pd
    from sklearn.ensemble import RandomForestClassifier
    from sklearn.model_selection import cross_val_score

    train = pd.read_csv('train.csv')
    X = train.drop('target', axis=1)
    y = train['target']

    model = RandomForestClassifier(n_estimators=100, random_state=42)
    scores = cross_val_score(model, X, y, cv=5)
    print(f"CV Score: {scores.mean():.4f}")
  initial_score: 0.75  # Optional, will be auto-evaluated if not provided
```

## Test Plan

- [x] Code syntax verified
- [x] Integration test with ML Agent example
- [ ] Verify initial_code is passed correctly to planner

Fixes #53